### PR TITLE
chore: re-add link to article about old MC versions

### DIFF
--- a/src/pages/downloads/all.tsx
+++ b/src/pages/downloads/all.tsx
@@ -43,7 +43,9 @@ const LegacyDownloads: NextPage<LegacyDownloadProps> = ({
       <div className="flex flex-col h-screen">
         <div className="h-14" />
         <div className="text-center px-4 py-2 font-bold bg-red-400 dark:bg-red-500 shadow-md">
-          Legacy builds are not supported. Proceed at your own risk!
+          <a href="https://madelinemiller.dev/blog/which-minecraft-version/">
+            Legacy builds are not supported. Proceed at your own risk!
+          </a>
         </div>
         <div className="flex-1 flex flex-row min-h-0">
           <DownloadsTree


### PR DESCRIPTION
Re-adds the link to the article about why old versions can be a bad idea to use, as linked by the old version of the site