### PR TITLE
Fix rounding error in player count

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -100,7 +100,7 @@ const Home: NextPage<ProjectProps> = ({ project }) => {
               Powering&nbsp;
               {playerData ? (
                 <span className="text-blue-500">
-                  {Math.round(playerData[0][1] / 1000)}k+
+                  {Math.floor(playerData[0][1] / 1000)}k+
                 </span>
               ) : (
                 <Skeleton className="w-30 h-6 inline-block" />


### PR DESCRIPTION
This PR updates `index.tsx` to use `Math.floor()` instead of `Math.round()` when displaying bStats player data. This ensures values like 30,600 do not get displayed as 31K+

P.S. Love the new website :)