### PR TITLE
Fix folia download link

### DIFF
--- a/src/pages/software/folia/index.tsx
+++ b/src/pages/software/folia/index.tsx
@@ -68,7 +68,7 @@ const FoliaHome = ({ project }: ProjectProps): ReactElement => {
 };
 
 FoliaHome.softwareProps = {
-  github: "https://github.com/FoliaMC/Folia",
+  github: "https://github.com/PaperMC/Folia",
 };
 
 export default FoliaHome;


### PR DESCRIPTION
I don't know if this is intentional but the github link of folia in the softwareProps is different from the 'official' github link.