### PR TITLE
Add Folia's support channels to the guidelines

### DIFF
--- a/src/pages/community/guidelines.tsx
+++ b/src/pages/community/guidelines.tsx
@@ -330,6 +330,12 @@ const CommunityGuidelines: NextPage = () => (
         <li>
           <code>#waterfall-dev</code>
         </li>
+        <li>
+          <code>#folia-help</code>
+        </li>
+        <li>
+          <code>#folia-dev</code>
+        </li>
       </ul>
     </section>
     <section

--- a/src/pages/community/guidelines.tsx
+++ b/src/pages/community/guidelines.tsx
@@ -398,7 +398,7 @@ const CommunityGuidelines: NextPage = () => (
       className="px-4 py-4 max-w-7xl mx-auto leading-7"
     >
       <h2 className="text-2xl font-medium mb-4">
-        Last Updated <code>2023-05-13</code>
+        Last Updated <code>2023-06-16</code>
       </h2>
       <p>
         This document is licensed under{" "}


### PR DESCRIPTION
Noticed while reading the guidelines that Folia's support channels aren't included.