### PR TITLE
fix "&ampos;" in community guidelines

### DIFF
--- a/src/pages/community/guidelines.tsx
+++ b/src/pages/community/guidelines.tsx
@@ -224,7 +224,7 @@ const CommunityGuidelines: NextPage = () => (
               general discussion of &apos;proper&apos; ways to disable safety
               features for legitimate reasons. Only trying to bypass them for
               the sake of avoiding accountability or otherwise being malicious
-              isn&ampos;t allowed.
+              isn&apos;t allowed.
             </li>
           </ol>
         </li>


### PR DESCRIPTION
![image](https://github.com/PaperMC/website/assets/85891155/56322602-d146-48a8-8f78-21809a6c526a)
