### PR TITLE
fix: conflicting z-index in build explorer

### DIFF
--- a/src/components/data/SoftwareBuildsTable.tsx
+++ b/src/components/data/SoftwareBuildsTable.tsx
@@ -20,7 +20,7 @@ const SoftwareBuildsTable = ({
 }: SoftwareBuildsTableProps) => {
   return (
     <table className="w-full relative">
-      <thead className="sticky top-0 z-50 bg-background-light-10 dark:bg-background-dark-90 shadow-sm">
+      <thead className="sticky top-0 z-40 bg-background-light-10 dark:bg-background-dark-90 shadow-sm">
         <tr className={styles.header}>
           <th>Build</th>
           <th>Changelog</th>


### PR DESCRIPTION
This fixes the conflicting z-index when hovering over the navbar in the [build explorer](https://papermc.io/downloads/all).

Resolves #69.