### PR TITLE
Fix build explorer timestamp going into a new line

### DIFF
--- a/src/components/data/SoftwareBuildsTable.tsx
+++ b/src/components/data/SoftwareBuildsTable.tsx
@@ -51,7 +51,10 @@ const SoftwareBuildsTable = ({
               <td>
                 <SoftwareBuildChanges project={project} build={build} />
               </td>
-              <td className={"whitespace-nowrap"} title={formatISODateTime(new Date(build.time))}>
+              <td
+                className={"whitespace-nowrap"}
+                title={formatISODateTime(new Date(build.time))}
+              >
                 {formatRelativeDate(new Date(build.time))}
               </td>
               <td className={"gap-1"}>

--- a/src/components/data/SoftwareBuildsTable.tsx
+++ b/src/components/data/SoftwareBuildsTable.tsx
@@ -51,7 +51,7 @@ const SoftwareBuildsTable = ({
               <td>
                 <SoftwareBuildChanges project={project} build={build} />
               </td>
-              <td title={formatISODateTime(new Date(build.time))}>
+              <td className={"whitespace-nowrap"} title={formatISODateTime(new Date(build.time))}>
                 {formatRelativeDate(new Date(build.time))}
               </td>
               <td className={"gap-1"}>


### PR DESCRIPTION
old:
![image](https://github.com/PaperMC/website/assets/70228790/bafc4491-5aad-427b-8eaa-6922d13524c6)
new:
![image](https://github.com/PaperMC/website/assets/70228790/a0ac5943-0a1c-4f8b-9828-b01de1eab52f)
