### PR TITLE
feat: use fill

### DIFF
--- a/src/components/data/SoftwareBuildChanges.tsx
+++ b/src/components/data/SoftwareBuildChanges.tsx
@@ -17,20 +17,20 @@ const SoftwareBuildChanges = ({
   version,
 }: SoftwareBuildChangesProps): ReactElement => (
   <>
-    {build.changes.map((change) => (
-      <p key={change.commit}>
+    {build.commits.map((change) => (
+      <p key={change.sha}>
         <a
-          href={`${getProjectRepository(project, version)}/commit/${change.commit}`}
+          href={`${getProjectRepository(project, version)}/commit/${change.sha}`}
           className={styles.commit}
           rel="noreferrer"
           target="_blank"
         >
-          {change.commit.slice(0, 7)}
+          {change.sha.slice(0, 7)}
         </a>
-        {highlightIssues(change.summary, project, styles.issue)}
+        {highlightIssues(change.message, project, styles.issue)}
       </p>
     ))}
-    {build.changes.length === 0 && <i className="text-gray-600">No changes</i>}
+    {build.commits.length === 0 && <i className="text-gray-600">No changes</i>}
   </>
 );
 

--- a/src/components/data/SoftwareBuilds.tsx
+++ b/src/components/data/SoftwareBuilds.tsx
@@ -5,7 +5,6 @@ import DownloadIcon from "@/assets/icons/heroicons/document-download.svg";
 import Skeleton from "@/components/data/Skeleton";
 import SoftwareBuildChanges from "@/components/data/SoftwareBuildChanges";
 import type { Build } from "@/lib/service/types";
-import { getVersionBuildDownloadURL } from "@/lib/service/v2";
 import { formatRelativeDate, formatISODateTime } from "@/lib/util/time";
 
 export interface SoftwareBuildsProps {
@@ -23,49 +22,38 @@ const SoftwareBuilds = ({
 }: SoftwareBuildsProps): ReactElement => (
   <div className="flex flex-col gap-1">
     {builds &&
-      builds
-        .slice()
-        .reverse()
-        .slice(0, 10)
-        .map((build) => (
-          <div
-            className="flex flex-row items-center hover:bg-blue-100 dark:hover:bg-gray-900 px-4 py-2 rounded-lg transition-colors"
-            key={build.build}
+      builds.slice(0, 10).map((build) => (
+        <div
+          className="flex flex-row items-center hover:bg-blue-100 dark:hover:bg-gray-900 px-4 py-2 rounded-lg transition-colors"
+          key={build.id}
+        >
+          {/* eslint-disable-next-line react/jsx-no-target-blank */}
+          <a
+            role="button"
+            href={build.downloads["server:default"].url}
+            target="_blank"
+            className={clsx(
+              "text-gray-100 text-sm text-center font-medium rounded-full p-2 min-w-16 mr-4 inline-flex items-center gap-1",
+              build.channel === "STABLE" && !eol ? "bg-gray-800" : "bg-red-500",
+            )}
           >
-            {/* eslint-disable-next-line react/jsx-no-target-blank */}
-            <a
-              role="button"
-              href={getVersionBuildDownloadURL(
-                project,
-                version,
-                build.build,
-                build.downloads["application"].name,
-              )}
-              target="_blank"
-              className={clsx(
-                "text-gray-100 text-sm text-center font-medium rounded-full p-2 min-w-16 mr-4 inline-flex items-center gap-1",
-                build.channel === "default" && !eol
-                  ? "bg-gray-800"
-                  : "bg-red-500",
-              )}
-            >
-              <DownloadIcon className="w-4 h-4" />#{build.build}
-            </a>
-            <div className="flex-1 flex flex-col text-gray-900 dark:text-gray-200">
-              <SoftwareBuildChanges
-                project={project}
-                build={build}
-                version={version}
-              />
-            </div>
-            <div
-              className="hidden md:block text-gray-500 dark:text-gray-300 mt-1 ml-2"
-              title={formatISODateTime(new Date(build.time))}
-            >
-              {formatRelativeDate(new Date(build.time))}
-            </div>
+            <DownloadIcon className="w-4 h-4" />#{build.id}
+          </a>
+          <div className="flex-1 flex flex-col text-gray-900 dark:text-gray-200">
+            <SoftwareBuildChanges
+              project={project}
+              build={build}
+              version={version}
+            />
           </div>
-        ))}
+          <div
+            className="hidden md:block text-gray-500 dark:text-gray-300 mt-1 ml-2"
+            title={formatISODateTime(new Date(build.time))}
+          >
+            {formatRelativeDate(new Date(build.time))}
+          </div>
+        </div>
+      ))}
     {!builds &&
       [...Array(5)].map((_, k) => (
         <div className="flex flex-row items-start w-full" key={k}>

--- a/src/components/data/SoftwareBuildsTable.tsx
+++ b/src/components/data/SoftwareBuildsTable.tsx
@@ -31,48 +31,45 @@ const SoftwareBuildsTable = ({
         </tr>
       </thead>
       <tbody className={styles.body}>
-        {builds
-          .slice()
-          .reverse()
-          .map((build) => (
-            <tr key={build.build}>
-              <td>
-                <span
-                  className={clsx(
-                    "text-sm font-medium text-gray-100 rounded-full py-2 px-3 min-w-16",
-                    build.channel === "experimental" || eol
-                      ? "bg-red-500"
-                      : "bg-gray-800",
-                  )}
-                >
-                  #{build.build}
-                </span>
-              </td>
-              <td>
-                <SoftwareBuildChanges
-                  project={project}
-                  build={build}
-                  version={version}
-                />
-              </td>
-              <td
-                className={"whitespace-nowrap"}
-                title={formatISODateTime(new Date(build.time))}
+        {builds.map((build) => (
+          <tr key={build.id}>
+            <td>
+              <span
+                className={clsx(
+                  "text-sm font-medium text-gray-100 rounded-full py-2 px-3 min-w-16",
+                  build.channel === "ALPHA" || build.channel === "BETA" || eol
+                    ? "bg-red-500"
+                    : "bg-gray-800",
+                )}
               >
-                {formatRelativeDate(new Date(build.time))}
-              </td>
-              <td className={"gap-1"}>
-                <SoftwareDownloadButton
-                  projectId={project}
-                  version={version}
-                  build={build}
-                  stable={build.channel === "default"}
-                  compact
-                  eol={eol}
-                />
-              </td>
-            </tr>
-          ))}
+                #{build.id}
+              </span>
+            </td>
+            <td>
+              <SoftwareBuildChanges
+                project={project}
+                build={build}
+                version={version}
+              />
+            </td>
+            <td
+              className={"whitespace-nowrap"}
+              title={formatISODateTime(new Date(build.time))}
+            >
+              {formatRelativeDate(new Date(build.time))}
+            </td>
+            <td className={"gap-1"}>
+              <SoftwareDownloadButton
+                projectId={project}
+                version={version}
+                build={build}
+                stable={build.channel === "STABLE"}
+                compact
+                eol={eol}
+              />
+            </td>
+          </tr>
+        ))}
       </tbody>
     </table>
   );

--- a/src/components/input/SoftwareDownloadButton.tsx
+++ b/src/components/input/SoftwareDownloadButton.tsx
@@ -8,7 +8,6 @@ import DocumentDownloadIcon from "@/assets/icons/heroicons/document-download.svg
 import Skeleton from "@/components/data/Skeleton";
 import type { ProjectDescriptor } from "@/lib/context/downloads";
 import type { Build } from "@/lib/service/types";
-import { getVersionBuildDownloadURL } from "@/lib/service/v2";
 import styles from "@/styles/components/input/SoftwareDownloadButton.module.css";
 
 export interface SoftwareDownloadButtonProps {
@@ -60,16 +59,7 @@ const SoftwareDownloadButton = ({
             "flex flex-row flex-1 items-center",
             compact ? "gap-2 pl-2 leading-0 py-1" : "gap-8 pl-5 py-3",
           )}
-          href={
-            projectId &&
-            build &&
-            getVersionBuildDownloadURL(
-              projectId,
-              version,
-              build.build,
-              build.downloads["application"].name,
-            )
-          }
+          href={projectId && build && build.downloads["server:default"].url}
           target="_blank"
         >
           <div className={compact ? "w-4 h-4" : "w-8 h-8"}>
@@ -83,9 +73,7 @@ const SoftwareDownloadButton = ({
                 <span className="font-medium text-lg">
                   {project?.name ?? projectId} {version}
                 </span>
-                <p className="text-gray-100">
-                  {build && `Build #${build.build}`}
-                </p>
+                <p className="text-gray-100">{build && `Build #${build.id}`}</p>
               </>
             ) : (
               <>
@@ -131,12 +119,7 @@ const SoftwareDownloadButton = ({
                       href={
                         projectId &&
                         build &&
-                        getVersionBuildDownloadURL(
-                          projectId,
-                          version,
-                          build.build,
-                          download.name,
-                        )
+                        build.downloads["server:default"].url
                       }
                       target="_blank"
                     >
@@ -148,20 +131,24 @@ const SoftwareDownloadButton = ({
                               Recommended
                             </span>
                           )}
-                          {copied === download.sha256 && (
+                          {copied === download.checksums.sha256 && (
                             <span className="ml-2 text-xs rounded-full py-0.5 px-2 bg-green-200/80 text-green-800">
                               Copied
                             </span>
                           )}
                         </div>
                         <div className="text-gray-700 dark:text-gray-300 text-xs inline-flex items-center w-full">
-                          <span className="truncate">{download.sha256}</span>
+                          <span className="truncate">
+                            {download.checksums.sha256}
+                          </span>
                           <button
                             className="ml-2 h-6 w-6"
                             onClick={(evt) => {
                               evt.preventDefault();
-                              navigator.clipboard.writeText(download.sha256);
-                              updateCopied(download.sha256);
+                              navigator.clipboard.writeText(
+                                download.checksums.sha256,
+                              );
+                              updateCopied(download.checksums.sha256);
                             }}
                           >
                             <CloneIcon className="h-4 w-4" />

--- a/src/components/layout/DownloadsTree.tsx
+++ b/src/components/layout/DownloadsTree.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 
 import ArchiveIcon from "@/assets/icons/fontawesome/box-archive.svg";
-import { useProject } from "@/lib/service/v2";
+import { useProject } from "@/lib/service/v3";
 
 interface ProjectSubTreeProps {
   id: string;
@@ -18,35 +18,33 @@ const ProjectSubTree = ({
   eol,
 }: ProjectSubTreeProps & DownloadsTreeProps) => {
   const { data: project } = useProject(id);
+  const flattenedVersions = Object.values(project?.versions ?? {}).flat();
 
   return (
     <>
       <div className="pl-3 py-1 rounded-md font-bold flex gap-2 items-center">
-        {project?.project_name ?? name}{" "}
+        {project?.project.id ?? name}{" "}
         {eol && <ArchiveIcon className="fill-current h-4" />}
       </div>
-      {project?.versions
-        ?.slice()
-        ?.reverse()
-        ?.map((version) => (
-          <button
-            key={version}
-            className={clsx(
-              "pl-6 py-1 rounded-md transition-colors text-gray-800 dark:text-gray-200 block w-full text-left",
-              eol
-                ? "hover:bg-red-100 hover:dark:bg-red-900"
-                : "hover:bg-blue-100 hover:dark:bg-gray-900",
-              selectedProject === id &&
-                selectedVersion === version &&
-                (eol
-                  ? "bg-red-100 dark:bg-red-900"
-                  : "bg-blue-100 dark:bg-blue-900"),
-            )}
-            onClick={() => onSelect(id, version)}
-          >
-            {version}
-          </button>
-        ))}
+      {flattenedVersions.map((version) => (
+        <button
+          key={version}
+          className={clsx(
+            "pl-6 py-1 rounded-md transition-colors text-gray-800 dark:text-gray-200 block w-full text-left",
+            eol
+              ? "hover:bg-red-100 hover:dark:bg-red-900"
+              : "hover:bg-blue-100 hover:dark:bg-gray-900",
+            selectedProject === id &&
+              selectedVersion === version &&
+              (eol
+                ? "bg-red-100 dark:bg-red-900"
+                : "bg-blue-100 dark:bg-blue-900"),
+          )}
+          onClick={() => onSelect(id, version)}
+        >
+          {version}
+        </button>
+      ))}
     </>
   );
 };

--- a/src/components/layout/SoftwareDownload.tsx
+++ b/src/components/layout/SoftwareDownload.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import SoftwareBuilds from "@/components/data/SoftwareBuilds";
 import SoftwareDownloadButton from "@/components/input/SoftwareDownloadButton";
 import type { ProjectProps } from "@/lib/context/downloads";
-import { useVersionBuilds } from "@/lib/service/v2";
+import { useVersionBuilds } from "@/lib/service/v3";
 
 export interface SoftwareDownloadProps {
   id: string;
@@ -30,7 +30,7 @@ const SoftwareDownload = ({
     ? project.latestStableVersion
     : (project.latestExperimentalVersion ?? project.latestStableVersion);
   const { data: builds } = useVersionBuilds(id, version);
-  const latestBuild = builds && builds.builds[builds.builds.length - 1];
+  const latestBuild = builds && builds[0];
 
   const toggleStable = () => {
     setStable(!isStable);
@@ -69,7 +69,7 @@ const SoftwareDownload = ({
               project={project}
               build={latestBuild}
               version={version}
-              stable={!latestBuild || latestBuild?.channel === "default"}
+              stable={!latestBuild || latestBuild?.channel === "STABLE"}
               eol={eol}
             />
             {project.latestExperimentalVersion && (
@@ -113,7 +113,7 @@ const SoftwareDownload = ({
         <SoftwareBuilds
           project={id}
           version={version}
-          builds={builds?.builds}
+          builds={builds}
           eol={eol}
         />
       </section>

--- a/src/lib/service/types.ts
+++ b/src/lib/service/types.ts
@@ -1,8 +1,10 @@
 export interface Project {
-  project_id: string;
-  project_name: string;
-  version_groups: string[];
-  versions: string[];
+  project: {
+    id: string;
+  };
+  versions: {
+    [key: string]: string[];
+  };
 }
 
 export interface ProjectVersion {
@@ -34,25 +36,30 @@ export interface VersionFamilyBuild extends Build {
 }
 
 export interface Build {
-  build: number;
+  id: number;
   time: string;
-  channel: "default" | "experimental";
-  promoted: boolean;
-  changes: BuildChange[];
-  downloads: Record<string, BuildDownload>;
+  channel: "ALPHA" | "BETA" | "STABLE" | "RECOMMENDED";
+  commits: BuildChange[];
+  downloads: {
+    [key: string]: BuildDownload;
+  };
 }
 
 export interface BuildChange {
-  commit: string;
-  summary: string;
+  sha: string;
   message: string;
+  time: string;
 }
 
 export interface BuildDownload {
   name: string;
-  sha256: string;
+  checksums: {
+    sha256: string;
+  };
+  size: number;
+  url: string;
 }
 
 export interface ProjectsResponse {
-  projects: string[];
+  projects: Project[];
 }

--- a/src/lib/service/v3.ts
+++ b/src/lib/service/v3.ts
@@ -3,14 +3,9 @@ import useSWR from "swr";
 
 import { swrNoAutoUpdateSettings } from "./api";
 
-import type {
-  Project,
-  ProjectsResponse,
-  VersionBuilds,
-  VersionFamilyBuilds,
-} from "@/lib/service/types";
+import type { Build, Project, ProjectsResponse } from "@/lib/service/types";
 
-const API_ENDPOINT = "https://api.papermc.io/v2";
+const API_ENDPOINT = "https://fill.papermc.io/v3";
 
 const fetcher = (path: string) =>
   fetch(API_ENDPOINT + path).then((res) => res.json());
@@ -24,19 +19,9 @@ export const useProject = (project: string): SWRResponse<Project> =>
 export const useVersionBuilds = (
   project: string,
   version: string,
-): SWRResponse<VersionBuilds> =>
+): SWRResponse<Build[]> =>
   useSWR(
     `/projects/${project}/versions/${version}/builds`,
-    fetcher,
-    swrNoAutoUpdateSettings,
-  );
-
-export const useVersionFamilyBuilds = (
-  project: string,
-  family: string,
-): SWRResponse<VersionFamilyBuilds> =>
-  useSWR(
-    `/projects/${project}/version_group/${family}/builds`,
     fetcher,
     swrNoAutoUpdateSettings,
   );
@@ -50,13 +35,5 @@ export const getProject = (project: string): Promise<Project> =>
 export const getVersionBuilds = (
   project: string,
   version: string,
-): Promise<VersionBuilds> =>
+): Promise<Build[]> =>
   getJSON(`/projects/${project}/versions/${version}/builds`);
-
-export const getVersionBuildDownloadURL = (
-  project: string,
-  version: string,
-  build: number,
-  file: string,
-): string =>
-  `${API_ENDPOINT}/projects/${project}/versions/${version}/builds/${build}/downloads/${file}`;


### PR DESCRIPTION
Swaps over to using Fill. Some functions from V2's service file weren't needed anymore (namely the download url builder). 

There's a few places where we flatten the versions object and where we no longer/reverse the build order. 