### PR TITLE
fix: use project name over ID in places

### DIFF
--- a/src/components/layout/DownloadsTree.tsx
+++ b/src/components/layout/DownloadsTree.tsx
@@ -23,7 +23,7 @@ const ProjectSubTree = ({
   return (
     <>
       <div className="pl-3 py-1 rounded-md font-bold flex gap-2 items-center">
-        {project?.project.id ?? name}{" "}
+        {project?.project.name ?? name}{" "}
         {eol && <ArchiveIcon className="fill-current h-4" />}
       </div>
       {flattenedVersions.map((version) => (

--- a/src/lib/context/downloads.ts
+++ b/src/lib/context/downloads.ts
@@ -58,7 +58,7 @@ export const getProjectProps = (
 ): GetStaticProps => {
   return async () => {
     const {
-      project: { id: projectId },
+      project: { name: projectName },
       versions,
     } = await getProject(id);
     const hangarProjectList: HangarProjectList | null = hangarProject
@@ -79,7 +79,7 @@ export const getProjectProps = (
         : null;
 
     const project: ProjectDescriptor = {
-      name: projectId,
+      name: projectName,
       latestStableVersion,
       latestExperimentalVersion,
       latestVersionGroup: Object.keys(versions)[0],

--- a/src/lib/service/types.ts
+++ b/src/lib/service/types.ts
@@ -1,6 +1,7 @@
 export interface Project {
   project: {
     id: string;
+    name: string;
   };
   versions: {
     [key: string]: string[];


### PR DESCRIPTION
Grabs the name for pages that capitalization matters. 