### PR TITLE
feat: add some QOL changes

### DIFF
--- a/src/components/data/SoftwareBuildChanges.tsx
+++ b/src/components/data/SoftwareBuildChanges.tsx
@@ -18,7 +18,7 @@ const SoftwareBuildChanges = ({
 }: SoftwareBuildChangesProps): ReactElement => (
   <>
     {build.commits.map((change) => (
-      <p key={change.sha}>
+      <p key={change.sha} className={styles.commitParagraph}>
         <a
           href={`${getProjectRepository(project, version)}/commit/${change.sha}`}
           className={styles.commit}

--- a/src/components/data/SoftwareBuildChanges.tsx
+++ b/src/components/data/SoftwareBuildChanges.tsx
@@ -27,7 +27,7 @@ const SoftwareBuildChanges = ({
         >
           {change.sha.slice(0, 7)}
         </a>
-        {highlightIssues(change.message, project, styles.issue)}
+        {formatCommitMessage(change.message, project, styles.issue)}
       </p>
     ))}
     {build.commits.length === 0 && <i className="text-gray-600">No changes</i>}
@@ -36,26 +36,64 @@ const SoftwareBuildChanges = ({
 
 export default SoftwareBuildChanges;
 
-const highlightIssues = (
+const formatCommitMessage = (
   summary: string,
   project: string,
   highlightClass: string,
 ): JSX.Element[] => {
-  return summary.split(/([^&])(#[0-9]+)/gm).map((part: string, i: number) => {
-    if (!part.match(/#[0-9]+/)) {
-      return <Fragment key={i}>{part}</Fragment>;
-    }
+  // Regex for issues (#123) and commit links
+  const regex =
+    /(@?https:\/\/github\.com\/[\w-]+\/[\w-]+\/commit\/([a-f0-9]{7,40}))|([^&])(#[0-9]+)/gim;
+  let lastIndex = 0;
+  let match;
+  const elements: JSX.Element[] = [];
+  let key = 0;
 
-    return (
-      <a
-        key={i}
-        className={highlightClass}
-        href={`https://github.com/PaperMC/${project}/issues/${part.slice(1)}`}
-        target="_blank"
-        rel="noreferrer"
-      >
-        {part}
-      </a>
-    );
-  });
+  // Use regex to find all matches
+  while ((match = regex.exec(summary)) !== null) {
+    // Add text before match
+    if (match.index > lastIndex) {
+      elements.push(
+        <Fragment key={key++}>
+          {summary.slice(lastIndex, match.index)}
+        </Fragment>,
+      );
+    }
+    if (match[2]) {
+      // Commit link
+      const url = match[1].replace(/^@/, "");
+      const shortHash = match[2].slice(0, 7);
+      elements.push(
+        <a
+          key={key++}
+          className={highlightClass}
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {shortHash}
+        </a>,
+      );
+    } else if (match[4]) {
+      // Issue reference
+      elements.push(
+        <Fragment key={key++}>{match[3]}</Fragment>,
+        <a
+          key={key++}
+          className={highlightClass}
+          href={`https://github.com/PaperMC/${project}/issues/${match[4].slice(1)}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {match[4]}
+        </a>,
+      );
+    }
+    lastIndex = regex.lastIndex;
+  }
+  // Add any remaining text
+  if (lastIndex < summary.length) {
+    elements.push(<Fragment key={key++}>{summary.slice(lastIndex)}</Fragment>);
+  }
+  return elements;
 };

--- a/src/components/data/SoftwareBuildChanges.tsx
+++ b/src/components/data/SoftwareBuildChanges.tsx
@@ -44,56 +44,56 @@ const formatCommitMessage = (
   // Regex for issues (#123) and commit links
   const regex =
     /(@?https:\/\/github\.com\/[\w-]+\/[\w-]+\/commit\/([a-f0-9]{7,40}))|([^&])(#[0-9]+)/gim;
-  let lastIndex = 0;
-  let match;
-  const elements: JSX.Element[] = [];
   let key = 0;
-
-  // Use regex to find all matches
-  while ((match = regex.exec(summary)) !== null) {
-    // Add text before match
-    if (match.index > lastIndex) {
-      elements.push(
-        <Fragment key={key++}>
-          {summary.slice(lastIndex, match.index)}
-        </Fragment>,
-      );
+  const trimmedSummary = summary.replace(/[\r\n]+$/g, "");
+  const lines = trimmedSummary.split(/\r?\n/);
+  const elements: JSX.Element[] = [];
+  lines.forEach((line, lineIdx) => {
+    let lastIndex = 0;
+    let match;
+    while ((match = regex.exec(line)) !== null) {
+      if (match.index > lastIndex) {
+        elements.push(
+          <Fragment key={key++}>{line.slice(lastIndex, match.index)}</Fragment>,
+        );
+      }
+      if (match[2]) {
+        // Commit link
+        const url = match[1].replace(/^@/, "");
+        const shortHash = match[2].slice(0, 7);
+        elements.push(
+          <a
+            key={key++}
+            className={highlightClass}
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {shortHash}
+          </a>,
+        );
+      } else if (match[4]) {
+        elements.push(
+          <Fragment key={key++}>{match[3]}</Fragment>,
+          <a
+            key={key++}
+            className={highlightClass}
+            href={`https://github.com/PaperMC/${project}/issues/${match[4].slice(1)}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {match[4]}
+          </a>,
+        );
+      }
+      lastIndex = regex.lastIndex;
     }
-    if (match[2]) {
-      // Commit link
-      const url = match[1].replace(/^@/, "");
-      const shortHash = match[2].slice(0, 7);
-      elements.push(
-        <a
-          key={key++}
-          className={highlightClass}
-          href={url}
-          target="_blank"
-          rel="noreferrer"
-        >
-          {shortHash}
-        </a>,
-      );
-    } else if (match[4]) {
-      // Issue reference
-      elements.push(
-        <Fragment key={key++}>{match[3]}</Fragment>,
-        <a
-          key={key++}
-          className={highlightClass}
-          href={`https://github.com/PaperMC/${project}/issues/${match[4].slice(1)}`}
-          target="_blank"
-          rel="noreferrer"
-        >
-          {match[4]}
-        </a>,
-      );
+    if (lastIndex < line.length) {
+      elements.push(<Fragment key={key++}>{line.slice(lastIndex)}</Fragment>);
     }
-    lastIndex = regex.lastIndex;
-  }
-  // Add any remaining text
-  if (lastIndex < summary.length) {
-    elements.push(<Fragment key={key++}>{summary.slice(lastIndex)}</Fragment>);
-  }
+    if (lineIdx < lines.length - 1) {
+      elements.push(<br key={key++} />);
+    }
+  });
   return elements;
 };

--- a/src/components/data/SoftwareBuilds.tsx
+++ b/src/components/data/SoftwareBuilds.tsx
@@ -39,7 +39,7 @@ const SoftwareBuilds = ({
           >
             <DownloadIcon className="w-4 h-4" />#{build.id}
           </a>
-          <div className="flex-1 flex flex-col text-gray-900 dark:text-gray-200">
+          <div className="flex-1 flex flex-col text-gray-900 dark:text-gray-200 min-w-0">
             <SoftwareBuildChanges
               project={project}
               build={build}

--- a/src/components/layout/DownloadsTree.tsx
+++ b/src/components/layout/DownloadsTree.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { forwardRef } from "react";
 
 import ArchiveIcon from "@/assets/icons/fontawesome/box-archive.svg";
 import { useProject } from "@/lib/service/fill";
@@ -22,7 +23,10 @@ const ProjectSubTree = ({
 
   return (
     <>
-      <div className="pl-3 py-1 rounded-md font-bold flex gap-2 items-center">
+      <div
+        className="pl-3 py-1 rounded-md font-bold flex gap-2 items-center"
+        data-project={id}
+      >
         {project?.project.name ?? name}{" "}
         {eol && <ArchiveIcon className="fill-current h-4" />}
       </div>
@@ -56,15 +60,22 @@ interface DownloadsTreeProps {
   onSelect(project: string, version: string): void;
 }
 
-const DownloadsTree = (props: DownloadsTreeProps) => {
-  return (
-    <nav className="w-50 p-2 border-r border-gray-300 overflow-auto">
-      <ProjectSubTree id="paper" name="Paper" {...props} />
-      <ProjectSubTree id="velocity" name="Velocity" {...props} />
-      <ProjectSubTree id="folia" name="Folia" {...props} />
-      <ProjectSubTree id="waterfall" name="Waterfall" eol {...props} />
-    </nav>
-  );
-};
+const DownloadsTree = forwardRef<HTMLDivElement, DownloadsTreeProps>(
+  (props, ref) => {
+    return (
+      <nav
+        ref={ref}
+        className="w-50 p-2 border-r border-gray-300 overflow-auto"
+      >
+        <ProjectSubTree id="paper" name="Paper" {...props} />
+        <ProjectSubTree id="velocity" name="Velocity" {...props} />
+        <ProjectSubTree id="folia" name="Folia" {...props} />
+        <ProjectSubTree id="waterfall" name="Waterfall" eol {...props} />
+      </nav>
+    );
+  },
+);
+
+DownloadsTree.displayName = "DownloadsTree";
 
 export default DownloadsTree;

--- a/src/components/layout/SoftwareDownload.tsx
+++ b/src/components/layout/SoftwareDownload.tsx
@@ -102,7 +102,7 @@ const SoftwareDownload = ({
           <span className="text-gray-700 dark:text-gray-400">
             Even older builds are available in our&nbsp;
             <Link
-              href="/downloads/all"
+              href={`/downloads/all?project=${id}`}
               className="text-gray-700 dark:text-gray-400 underline"
             >
               build explorer

--- a/src/pages/downloads/all.tsx
+++ b/src/pages/downloads/all.tsx
@@ -1,5 +1,6 @@
 import type { GetStaticProps, NextPage } from "next";
-import { useState } from "react";
+import { useRouter } from "next/router";
+import { useState, useEffect, useRef } from "react";
 
 import SoftwareBuildsTable from "@/components/data/SoftwareBuildsTable";
 import DownloadsTree from "@/components/layout/DownloadsTree";
@@ -29,17 +30,65 @@ const LegacyDownloads: NextPage<LegacyDownloadProps> = ({
   initialProjectId,
   initialProjectVersion,
 }) => {
+  const router = useRouter();
+  const downloadsTreeRef = useRef<HTMLDivElement>(null);
   const [selectedProject, setSelectedProject] = useState(initialProjectId);
   const [selectedVersion, setSelectedVersion] = useState(initialProjectVersion);
   const { data: builds } = useVersionBuilds(selectedProject, selectedVersion);
   const { data: project } = useProject(selectedProject);
+
+  // Auto-select project from query parameter
+  useEffect(() => {
+    const { project: projectParam } = router.query;
+    if (projectParam && typeof projectParam === "string") {
+      const validProjects = ["paper", "velocity", "folia", "waterfall"];
+      if (validProjects.includes(projectParam)) {
+        setSelectedProject(projectParam);
+        // Fetch the project and set the first version
+        getProject(projectParam).then((proj) => {
+          const flattenedVersions = Object.values(proj.versions).flat();
+          if (flattenedVersions.length > 0) {
+            setSelectedVersion(flattenedVersions[0]);
+          }
+        });
+        // Scroll to the selected project after a short delay to ensure the tree is rendered
+        setTimeout(() => {
+          const projectElement = downloadsTreeRef.current?.querySelector(
+            `[data-project="${projectParam}"]`,
+          );
+          if (projectElement) {
+            projectElement.scrollIntoView({
+              behavior: "smooth",
+              block: "center",
+            });
+          }
+        }, 100);
+      }
+    }
+  }, [router.query]);
+
+  // Handler for selecting a project/version from the tree
+  const handleSelect = (project: string, version?: string) => {
+    setSelectedProject(project);
+    if (version) {
+      setSelectedVersion(version);
+    } else {
+      // Fetch the project and set the first version
+      getProject(project).then((proj) => {
+        const flattenedVersions = Object.values(proj.versions).flat();
+        if (flattenedVersions.length > 0) {
+          setSelectedVersion(flattenedVersions[0]);
+        }
+      });
+    }
+  };
 
   const eol = selectedProject === "waterfall";
   const flattenedVersions = Object.values(project?.versions ?? {}).flat();
   const latestVersion = flattenedVersions[0];
   const legacy = selectedVersion !== latestVersion;
   const experimental =
-    builds?.[0].channel === "ALPHA" || builds?.[0].channel === "BETA";
+    builds?.[0]?.channel === "ALPHA" || builds?.[0]?.channel === "BETA";
 
   return (
     <>
@@ -53,12 +102,10 @@ const LegacyDownloads: NextPage<LegacyDownloadProps> = ({
         <div className="h-16" />
         <div className="flex-1 flex flex-row min-h-0">
           <DownloadsTree
+            ref={downloadsTreeRef}
             selectedProject={selectedProject}
             selectedVersion={selectedVersion}
-            onSelect={(project, version) => {
-              setSelectedProject(project);
-              setSelectedVersion(version);
-            }}
+            onSelect={handleSelect}
           />
           <div className="flex-1 overflow-auto">
             {legacy && (
@@ -84,7 +131,7 @@ const LegacyDownloads: NextPage<LegacyDownloadProps> = ({
             <SoftwareBuildsTable
               project={selectedProject}
               version={selectedVersion}
-              builds={builds ?? []}
+              builds={Array.isArray(builds) ? builds : []}
               eol={eol}
             />
           </div>

--- a/styles/components/data/SoftwareBuildChanges.module.css
+++ b/styles/components/data/SoftwareBuildChanges.module.css
@@ -2,6 +2,10 @@
     @apply text-blue-600 dark:text-blue-500 mr-1 font-mono;
 }
 
+.commitParagraph {
+    @apply break-words whitespace-normal w-full;
+}
+
 .issue {
     @apply text-blue-600 dark:text-blue-500;
 }


### PR DESCRIPTION
- Build explorer now supports a `project` query parameter to auto scroll and select the given project
- Gracefully handle invalid versions
- Word wrap long commit messages
  - Technically was done previously but only for the first commit for a build
- Direct links to commits are now parsed out into `a` tags
- Newlines in the commit messages are converted into `br` tags to make reading formatted commits easier