### PR TITLE
Use project name instead of project ID in GitHub links

### DIFF
--- a/src/app/downloads/all/downloads-all-client.tsx
+++ b/src/app/downloads/all/downloads-all-client.tsx
@@ -136,7 +136,13 @@ export default function DownloadsAllClient({ initialProjectId, initialProjectVer
               EOL builds are not supported. Proceed at your own risk!
             </div>
           )}
-          <SoftwareBuildsTable project={selectedProject} version={selectedVersion} builds={builds ?? []} eol={eol} />
+          <SoftwareBuildsTable
+            project={selectedProject}
+            projectName={project?.project.name || selectedProject}
+            version={selectedVersion}
+            builds={builds ?? []}
+            eol={eol}
+          />
         </div>
       </div>
     </div>

--- a/src/components/data/SoftwareBuildChanges.tsx
+++ b/src/components/data/SoftwareBuildChanges.tsx
@@ -7,11 +7,12 @@ import styles from "@/styles/components/data/SoftwareBuildChanges.module.css";
 
 export interface SoftwareBuildChangesProps {
   project: string;
+  projectName?: string;
   build: Build;
   version: string;
 }
 
-const SoftwareBuildChanges = ({ project, build, version }: SoftwareBuildChangesProps) => (
+const SoftwareBuildChanges = ({ project, projectName, build, version }: SoftwareBuildChangesProps) => (
   <>
     {build.commits.map((change) => {
       const [firstLine, ...restLines] = change.message.split(/\r?\n/);
@@ -21,14 +22,14 @@ const SoftwareBuildChanges = ({ project, build, version }: SoftwareBuildChangesP
       return (
         <p key={change.sha} className={styles.commitMessage}>
           <a
-            href={`${getProjectRepository(project, version)}/commit/${change.sha}`}
+            href={`${getProjectRepository(project, version, projectName)}/commit/${change.sha}`}
             className={styles.commit}
             rel="noreferrer"
             target="_blank"
           >
             {change.sha.slice(0, 7)}
           </a>
-          <span title={fullMessage}>{formatCommitMessage(firstLine, project, styles.issue)}</span>
+          <span title={fullMessage}>{formatCommitMessage(firstLine, project, styles.issue, projectName)}</span>
         </p>
       );
     })}
@@ -38,7 +39,12 @@ const SoftwareBuildChanges = ({ project, build, version }: SoftwareBuildChangesP
 
 export default SoftwareBuildChanges;
 
-const formatCommitMessage = (summary: string, project: string, highlightClass: string): ReactElement[] => {
+const formatCommitMessage = (
+  summary: string,
+  project: string,
+  highlightClass: string,
+  projectName?: string,
+): ReactElement[] => {
   // Regex for issues (#123) and commit links
   const regex = /(@?https:\/\/github\.com\/[\w-]+\/[\w-]+\/commit\/([a-f0-9]{7,40}))|([^&])(#[0-9]+)/gim;
   let key = 0;
@@ -65,7 +71,7 @@ const formatCommitMessage = (summary: string, project: string, highlightClass: s
         <a
           key={key++}
           className={highlightClass}
-          href={`https://github.com/PaperMC/${project}/issues/${match[4].slice(1)}`}
+          href={`https://github.com/PaperMC/${projectName || project}/issues/${match[4].slice(1)}`}
           target="_blank"
           rel="noreferrer"
         >

--- a/src/components/data/SoftwareBuilds.tsx
+++ b/src/components/data/SoftwareBuilds.tsx
@@ -8,11 +8,12 @@ import { formatISODateTime, formatRelativeDate } from "@/lib/util/time";
 
 export interface SoftwareBuildsProps {
   project: string;
+  projectName?: string;
   version: string;
   builds?: Build[];
   eol?: boolean;
 }
-const SoftwareBuilds = ({ project, version, builds, eol }: SoftwareBuildsProps) => (
+const SoftwareBuilds = ({ project, projectName, version, builds, eol }: SoftwareBuildsProps) => (
   <div className="flex flex-col">
     {builds &&
       builds.slice(0, 10).map((build, idx) => (
@@ -33,7 +34,7 @@ const SoftwareBuilds = ({ project, version, builds, eol }: SoftwareBuildsProps) 
               <DownloadIcon className="w-4 h-4" />#{build.id}
             </a>
             <div className="flex-1 flex flex-col text-gray-900 dark:text-gray-200 min-w-0">
-              <SoftwareBuildChanges project={project} build={build} version={version} />
+              <SoftwareBuildChanges project={project} build={build} version={version} projectName={projectName} />
             </div>
             <div
               className="hidden md:block text-gray-500 dark:text-gray-300 mt-1 ml-2"

--- a/src/components/data/SoftwareBuildsTable.tsx
+++ b/src/components/data/SoftwareBuildsTable.tsx
@@ -9,12 +9,13 @@ import styles from "@/styles/components/data/SoftwareBuildsTable.module.css";
 
 export interface SoftwareBuildsTableProps {
   project: string;
+  projectName?: string;
   version: string;
   builds: Build[];
   eol?: boolean;
 }
 
-const SoftwareBuildsTable = ({ project, version, builds, eol }: SoftwareBuildsTableProps) => {
+const SoftwareBuildsTable = ({ project, projectName, version, builds, eol }: SoftwareBuildsTableProps) => {
   return (
     <div className="overflow-x-auto">
       <table className="w-full relative">
@@ -40,7 +41,7 @@ const SoftwareBuildsTable = ({ project, version, builds, eol }: SoftwareBuildsTa
                 </span>
               </td>
               <td>
-                <SoftwareBuildChanges project={project} build={build} version={version} />
+                <SoftwareBuildChanges project={project} projectName={projectName} build={build} version={version} />
               </td>
               <td className={"whitespace-nowrap"} title={formatISODateTime(new Date(build.time))}>
                 {formatRelativeDate(new Date(build.time))}

--- a/src/components/layout/SoftwareDownload.tsx
+++ b/src/components/layout/SoftwareDownload.tsx
@@ -105,7 +105,7 @@ const SoftwareDownload = ({
             .
           </span>
         </p>
-        <SoftwareBuilds project={id} version={version} builds={builds} eol={eol} />
+        <SoftwareBuilds project={id} projectName={project.name} version={version} builds={builds} eol={eol} />
       </section>
     </>
   );

--- a/src/lib/service/github.ts
+++ b/src/lib/service/github.ts
@@ -22,8 +22,8 @@ const getURL = (pageIndex: number, previousPageData: any): string | null => {
 export const useGitHubContributors = (): SWRInfiniteResponse<Contributor[]> =>
   useSWRInfinite(getURL, fetcher, swrNoAutoUpdateSettings);
 
-export const getProjectRepository = (project: string, version: string): string => {
-  if (project !== "paper") return `https://github.com/PaperMC/${project}`;
+export const getProjectRepository = (project: string, version: string, projectName?: string): string => {
+  if (project !== "paper") return `https://github.com/PaperMC/${projectName || project}`;
   if (project == "paper" && version == "1.7.10") return "https://github.com/PaperMC/Paper-1.7";
 
   const baseVersion = [21, 4]; // 1.21.4 is after the hardfork


### PR DESCRIPTION
Although GitHub will correct the URL correctly, it is best to use the correct URL.
If the project name cannot be found, the project ID will still be used.

Before:
<img width="913" height="286" alt="image" src="https://github.com/user-attachments/assets/34e2749f-61b0-4457-8331-dd745110f480" />

After:
<img width="904" height="285" alt="image" src="https://github.com/user-attachments/assets/dfeac99a-4a99-49ce-82db-991c917656e9" />
