### PR TITLE
fix: header clear on initial scroll

### DIFF
--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -45,8 +45,8 @@ const NavBar = () => {
   return (
     <nav
       className={clsx(
-        "fixed top-0 left-0 right-0 z-50 transition-shadow",
-        scroll && "bg-background-light-10 dark:bg-background-dark-90 shadow-xl",
+        "fixed top-0 left-0 right-0 z-50 transition-shadow bg-background-light-10 dark:bg-background-dark-90",
+        scroll && "shadow-xl",
       )}
     >
       <div className="max-w-7xl flex flex-row items-center mx-auto px-4 py-2 gap-2">


### PR DESCRIPTION
The NavBars background color is only added after 64px of scroll. It just bugs me every time I use this page lol.

**Before:**
<img width="2246" height="341" alt="image" src="https://github.com/user-attachments/assets/78cc3d4a-4237-4e21-b0c4-f9f480a461db" />

**After:**
<img width="2246" height="341" alt="image" src="https://github.com/user-attachments/assets/f9daf3ae-b121-4f75-95d3-fb18ff69f256" />

The shadow is still added after a bit of scroll as before. 