### PR TITLE
chore(ci): add workflow to close PRs opened from the main branch

### DIFF
--- a/.github/workflows/close_invalid_prs.yml
+++ b/.github/workflows/close_invalid_prs.yml
@@ -1,0 +1,27 @@
+name: Close invalid PRs
+
+on:
+  pull_request_target:
+    types: [ opened ]
+
+jobs:
+  run:
+    if: |
+      github.repository != github.event.pull_request.head.repo.full_name &&
+      (
+        github.head_ref == 'main' ||
+        github.event.pull_request.head.repo.owner.type != 'User'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: superbrothers/close-pull-request@v3
+        id: "main_branch"
+        if: github.head_ref == 'main'
+        with:
+          comment: "Please do not open pull requests from the `main` branch, create a new branch instead."
+
+      - uses: superbrothers/close-pull-request@v3
+        id: "org_account"
+        if: github.event.pull_request.head.repo.owner.type != 'User' && steps.main_branch.outcome == 'skipped'
+        with:
+          comment: "Please do not open pull requests from non-user accounts like organizations. Create a fork on a user account instead."


### PR DESCRIPTION
related to https://github.com/PaperMC/website/pull/333 where touch default branchs can cause issues i take the workflow of paper for check the origin of PR branchs.