### PR TITLE
perf: reduce downloads page cache staleness

### DIFF
--- a/src/pages/downloads/folia.astro
+++ b/src/pages/downloads/folia.astro
@@ -5,8 +5,7 @@ import Layout from "@/layouts/Layout.astro";
 import SoftwareDownloadPage from "@/components/data/SoftwareDownloadPage.svelte";
 import { fetchDownloadsPageData } from "@/utils/download";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=300, s-maxage=600, stale-while-revalidate=120");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600, stale-while-revalidate=120");
+Astro.response.headers.set("Cache-Control", "private, max-age=60");
 const data = await fetchDownloadsPageData("folia", env.WEBSITE_CACHE);
 ---
 

--- a/src/pages/downloads/paper.astro
+++ b/src/pages/downloads/paper.astro
@@ -5,8 +5,7 @@ import Layout from "@/layouts/Layout.astro";
 import SoftwareDownloadPage from "@/components/data/SoftwareDownloadPage.svelte";
 import { fetchDownloadsPageData } from "@/utils/download";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=300, s-maxage=600, stale-while-revalidate=120");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600, stale-while-revalidate=120");
+Astro.response.headers.set("Cache-Control", "private, max-age=60");
 const data = await fetchDownloadsPageData("paper", env.WEBSITE_CACHE);
 ---
 

--- a/src/pages/downloads/velocity.astro
+++ b/src/pages/downloads/velocity.astro
@@ -5,8 +5,7 @@ import Layout from "@/layouts/Layout.astro";
 import SoftwareDownloadPage from "@/components/data/SoftwareDownloadPage.svelte";
 import { fetchDownloadsPageData } from "@/utils/download";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=300, s-maxage=600, stale-while-revalidate=120");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600, stale-while-revalidate=120");
+Astro.response.headers.set("Cache-Control", "private, max-age=60");
 const data = await fetchDownloadsPageData("velocity", env.WEBSITE_CACHE);
 ---
 

--- a/src/pages/downloads/waterfall.astro
+++ b/src/pages/downloads/waterfall.astro
@@ -5,8 +5,7 @@ import Layout from "@/layouts/Layout.astro";
 import SoftwareDownloadPage from "@/components/data/SoftwareDownloadPage.svelte";
 import { fetchDownloadsPageData } from "@/utils/download";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=300, s-maxage=600, stale-while-revalidate=120");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=600, stale-while-revalidate=120");
+Astro.response.headers.set("Cache-Control", "private, max-age=60");
 const data = await fetchDownloadsPageData("waterfall", env.WEBSITE_CACHE);
 
 const descriptionHtml = `


### PR DESCRIPTION
The download pages are SSR Worker responses. Workers Cache is not enabled in
the current deployment, so the shared-cache directives do not currently
provide edge caching for these routes.

Astro supports route-level Workers Cache configuration, but does not
automatically generate a dedicated cache-enabled Worker entrypoint for SSR
routes that would benefit from caching. Enabling Workers Cache on the default
entrypoint would also make static asset requests incur standard Workers
request charges, even on cache hits.

Use a private 60-second browser cache for the download pages instead, while
preserving the existing long-lived static asset caching.
