### PR TITLE
chore: improve Fill sync and downloads cache observability

### DIFF
--- a/src/pages/internal-api/terminal.ts
+++ b/src/pages/internal-api/terminal.ts
@@ -21,6 +21,8 @@ export const GET: APIRoute = async () => {
     const foundVer = projectDescriptor.value?.latestStableVersion;
     if (foundVer) {
       ver = foundVer;
+    } else {
+      console.warn("Failed to determine the Paper version for the terminal endpoint:", projectDescriptor.error);
     }
   }
 

--- a/src/pages/webhooks/fill.ts
+++ b/src/pages/webhooks/fill.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
-import { isDownloadProjectId, refreshDownloadsPageCache } from "@/utils/download";
+import { DOWNLOAD_PROJECT_IDS, isDownloadProjectId, refreshDownloadsPageCache } from "@/utils/download";
 
 export const prerender = false;
 
@@ -18,6 +18,7 @@ function acknowledge(): Response {
 export const POST: APIRoute = async ({ request, locals }) => {
   const secret = env.FILL_WEBHOOK_SECRET;
   if (!secret) {
+    console.warn("Received Fill webhook but FILL_WEBHOOK_SECRET is not configured");
     return Response.json({ error: "Fill webhooks are not configured on this deployment" }, { status: 503 });
   }
 
@@ -26,12 +27,16 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const signature = request.headers.get("webhook-signature");
 
   if (!deliveryId || !timestamp || !signature) {
+    console.warn(
+      `Received Fill webhook with missing Standard Webhooks headers: deliveryId=${deliveryId ?? "missing"} timestamp=${timestamp ?? "missing"} hasSignature=${Boolean(signature)}`
+    );
     return Response.json({ error: "Missing Standard Webhooks headers" }, { status: 400 });
   }
 
   const nowSeconds = Math.floor(Date.now() / 1000);
   const timestampSeconds = Number(timestamp);
   if (!Number.isInteger(timestampSeconds) || Math.abs(nowSeconds - timestampSeconds) > TIMESTAMP_TOLERANCE_SECONDS) {
+    console.warn(`Received Fill webhook ${deliveryId} with timestamp outside tolerance: timestamp=${timestamp} now=${nowSeconds}`);
     return Response.json({ error: "Webhook timestamp outside tolerance" }, { status: 401 });
   }
 
@@ -40,11 +45,13 @@ export const POST: APIRoute = async ({ request, locals }) => {
   let signatureMatches: boolean;
   try {
     signatureMatches = await verifySignature(secret, `${deliveryId}.${timestamp}.${body}`, signature);
-  } catch {
+  } catch (error) {
+    console.error(`Failed to verify Fill webhook ${deliveryId}: invalid secret configuration`, error);
     return Response.json({ error: "Fill webhooks are not configured with a valid secret" }, { status: 503 });
   }
 
   if (!signatureMatches) {
+    console.warn(`Received Fill webhook ${deliveryId} with invalid signature`);
     return Response.json({ error: "Invalid webhook signature" }, { status: 401 });
   }
 
@@ -52,21 +59,29 @@ export const POST: APIRoute = async ({ request, locals }) => {
   try {
     payload = JSON.parse(body);
   } catch {
+    console.warn(`Received Fill webhook ${deliveryId} with invalid JSON body`);
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
   if (typeof payload.type !== "string" || !SUPPORTED_TYPES.has(payload.type)) {
-    // Unknown event type: acknowledge and ignore.
+    console.log(`Ignoring Fill webhook ${deliveryId}: unsupported type ${JSON.stringify(payload.type)}`);
     return acknowledge();
   }
 
   const project = payload.data?.project?.key;
+
   if (!isDownloadProjectId(project)) {
-    // Project not in the cached set: acknowledge and ignore.
+    console.log(
+      `Ignoring Fill webhook ${deliveryId} (${payload.type}): project ${JSON.stringify(project)} not in cached set [${DOWNLOAD_PROJECT_IDS.join(", ")}]`
+    );
     return acknowledge();
   }
 
-  const refresh = refreshDownloadsPageCache(project, env.WEBSITE_CACHE);
+  console.log(`Fill webhook ${deliveryId} (${payload.type}): refreshing downloads cache for ${project}`);
+
+  const refresh = refreshDownloadsPageCache({ projectId: project, kv: env.WEBSITE_CACHE, logUnchanged: true }).catch((error) => {
+    console.error(`Failed to refresh downloads cache for ${project} after webhook ${deliveryId}:`, error);
+  });
   if (locals.cfContext) {
     locals.cfContext.waitUntil(refresh);
   } else {

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -23,15 +23,73 @@ export function downloadsPageDataKvKey(projectId: string) {
   return `downloads:${projectId}`;
 }
 
-export async function refreshDownloadsPageCache(projectId: string, kv: KVNamespace): Promise<void> {
-  const data = await fetchDownloadsPageData(projectId);
+function downloadsPageDataErrors(data: DownloadsPageData) {
   if (
     data.projectResult.error === undefined &&
     data.stableBuildsResult.error === undefined &&
     data.experimentalBuildsResult?.error === undefined
   ) {
-    await kv.put(downloadsPageDataKvKey(projectId), JSON.stringify(data));
+    return null;
   }
+
+  return {
+    projectError: data.projectResult.error,
+    stableError: data.stableBuildsResult.error,
+    experimentalError: data.experimentalBuildsResult?.error,
+  };
+}
+
+export async function refreshDownloadsPageCache({
+  projectId,
+  kv,
+  logUnchanged = false,
+}: {
+  projectId: string;
+  kv: KVNamespace;
+  logUnchanged?: boolean;
+}): Promise<void> {
+  // `null` means the key does not exist yet; `undefined` means the read failed.
+  const previousRaw = await kv.get(downloadsPageDataKvKey(projectId)).catch((error) => {
+    console.warn(`Failed to read previous cache for ${projectId} before refresh:`, error);
+    return undefined;
+  });
+
+  const data = await fetchDownloadsPageData(projectId);
+
+  const errors = downloadsPageDataErrors(data);
+  if (errors) {
+    console.warn(`Not updating cache for ${projectId}: fetch returned errors`, errors);
+    return;
+  }
+
+  // Stored values are written by this exact serialization, so comparing raw strings is a reliable change check.
+  const serialized = JSON.stringify(data);
+
+  if (previousRaw === serialized) {
+    if (logUnchanged) {
+      console.log(`Cache already current for ${projectId}: ${describeDownloadsPageData(data)}`);
+    }
+    return;
+  }
+
+  await kv.put(downloadsPageDataKvKey(projectId), serialized);
+
+  const initial = previousRaw === null ? " (initial population)" : "";
+  console.log(`Updated cache for ${projectId}: ${describeDownloadsPageData(data)}${initial}`);
+}
+
+/** One-line summary of the stable/experimental state stored in the downloads page cache. */
+function describeDownloadsPageData(data: DownloadsPageData): string {
+  const project = data.projectResult.value;
+  const stable = formatVersionSummary("stable", project?.latestStableVersion, data.stableBuildsResult.value);
+  const experimental = data.experimentalBuildsResult?.value;
+  if (!experimental) return stable;
+  return `${stable}, ${formatVersionSummary("experimental", project?.latestExperimentalVersion, experimental)}`;
+}
+
+/** Renders one cached version line, e.g. "stable v1.21.8 latest=2544 (3 builds)". */
+function formatVersionSummary(label: string, version: string | null | undefined, result: ProjectBuildsOrError["value"]): string {
+  return `${label} v${version ?? "unknown"} latest=${result?.latest?.id ?? "none"} (${result?.builds.length ?? 0} builds)`;
 }
 
 export async function fetchDownloadsPageData(projectId: string, kv?: KVNamespace): Promise<DownloadsPageData> {
@@ -60,7 +118,14 @@ export async function fetchDownloadsPageData(projectId: string, kv?: KVNamespace
 
   const [stableBuildsResult, experimentalBuildsResult] = await Promise.all([stableBuildsResultPromise, experimentalBuildsResultPromise]);
 
-  return { projectResult, stableBuildsResult, experimentalBuildsResult };
+  const data = { projectResult, stableBuildsResult, experimentalBuildsResult };
+  if (kv) {
+    const errors = downloadsPageDataErrors(data);
+    if (errors) {
+      console.warn(`Failed to fully populate downloads page data for ${projectId} after a cache miss`, errors);
+    }
+  }
+  return data;
 }
 
 export async function fetchBuildsOrError(projectId: string, versionId: string): Promise<ProjectBuildsOrError> {
@@ -92,44 +157,48 @@ async function findStableAndExperimentalVersions(
   project: Project
 ): Promise<{ latestStableVersion: string; latestExperimentalVersion: string | null }> {
   const flattenedVersions = Object.values(project.versions).flat().reverse();
-  let latestStableVersion = flattenedVersions[flattenedVersions.length - 1];
+  const newestVersion = flattenedVersions[flattenedVersions.length - 1];
+  if (!newestVersion) {
+    throw new Error(`Project ${project.project.id} has no versions`);
+  }
+
+  let latestStableVersion: string | undefined;
 
   // Check for stable builds
   for (let i = flattenedVersions.length - 1; i >= 0; i--) {
     if (preReleaseRegex.test(flattenedVersions[i])) continue; // Skip pre-release versions
     try {
       const build = await getLatestBuild(project.project.id, flattenedVersions[i]);
-      if (build !== null && (build.channel === "STABLE" || build.channel === "RECOMMENDED")) {
+      if (build === null) continue;
+      if (build.channel === "STABLE" || build.channel === "RECOMMENDED") {
         latestStableVersion = flattenedVersions[i];
         break;
       }
-    } catch {
-      // Continue to next version if this one fails
+    } catch (error) {
+      throw new Error(`Failed to determine whether ${project.project.id} ${flattenedVersions[i]} is stable`, { cause: error });
     }
   }
 
-  const latestExperimentalVersion =
-    latestStableVersion !== flattenedVersions[flattenedVersions.length - 1] ? flattenedVersions[flattenedVersions.length - 1] : null;
+  if (!latestStableVersion) {
+    throw new Error(`Project ${project.project.id} has no version with a stable or recommended build`);
+  }
+
+  const latestExperimentalVersion = latestStableVersion !== newestVersion ? newestVersion : null;
 
   return { latestStableVersion, latestExperimentalVersion };
 }
 
-export async function getProjectDescriptor(id: string): Promise<ProjectDescriptor | null> {
-  try {
-    const projectData = await getProject(id);
-    const { latestStableVersion, latestExperimentalVersion } = await findStableAndExperimentalVersions(projectData);
+export async function getProjectDescriptor(id: string): Promise<ProjectDescriptor> {
+  const projectData = await getProject(id);
+  const { latestStableVersion, latestExperimentalVersion } = await findStableAndExperimentalVersions(projectData);
 
-    return {
-      id,
-      name: projectData.project.name,
-      latestStableVersion,
-      latestExperimentalVersion,
-      latestVersionGroup: Object.keys(projectData.versions)[0],
-    };
-  } catch (error) {
-    console.error(`Failed to fetch project ${id}:`, error);
-    return null;
-  }
+  return {
+    id,
+    name: projectData.project.name,
+    latestStableVersion,
+    latestExperimentalVersion,
+    latestVersionGroup: Object.keys(projectData.versions)[0],
+  };
 }
 
 export async function getProjectDescriptorWithHangar(id: string): Promise<{ project: ProjectDescriptor; hangarCount: number } | null> {

--- a/src/utils/fill.ts
+++ b/src/utils/fill.ts
@@ -4,7 +4,10 @@ const API_ENDPOINT = "https://fill.papermc.io/v3";
 const USER_AGENT = "PaperMC/website (+https://papermc.io)";
 
 export async function getProject(project: string): Promise<Project> {
-  const res = await fetch(`${API_ENDPOINT}/projects/${project}`, { headers: { "User-Agent": USER_AGENT } });
+  const res = await fetch(`${API_ENDPOINT}/projects/${project}`, {
+    headers: { "User-Agent": USER_AGENT },
+    cache: "no-store",
+  });
   if (!res.ok) {
     throw new Error(`getProject(${project}) failed: ${res.status}`);
   }
@@ -16,7 +19,10 @@ export async function getVersionBuilds(project: string, version: string, channel
   if (channel) {
     url += `?channel=${encodeURIComponent(channel)}`;
   }
-  const res = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
+  const res = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+    cache: "no-store",
+  });
   if (!res.ok) {
     throw new Error(`getVersionBuilds(${project}, ${version}, ${channel}) failed: ${res.status}`);
   }
@@ -25,9 +31,15 @@ export async function getVersionBuilds(project: string, version: string, channel
 
 export async function getLatestBuild(project: string, version: string): Promise<Build | null> {
   const url = `${API_ENDPOINT}/projects/${project}/versions/${version}/builds/latest`;
-  const res = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
+  const res = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+    cache: "no-store",
+  });
   if (!res.ok) {
     throw new Error(`getLatestBuild(${project}, ${version}) failed: ${res.status}`);
   }
-  return res.json() as Promise<Build>;
+  if (res.status === 204) {
+    return null;
+  }
+  return res.json() as Promise<Build | null>;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11,7 +11,12 @@ export default {
   },
   async scheduled(controller, env, _ctx) {
     if (controller.cron === PLAYER_COUNT_CRON) {
-      await updateStatsCache(env);
+      try {
+        await updateStatsCache(env);
+      } catch (error) {
+        console.error("Scheduled player count cache update failed:", error);
+        throw error;
+      }
     } else if (controller.cron === DOWNLOADS_RECONCILIATION_CRON) {
       await updateDownloadsPageCache(env);
     }
@@ -20,13 +25,20 @@ export default {
 
 async function updateDownloadsPageCache(env: Env) {
   for (const project of DOWNLOAD_PROJECT_IDS) {
-    await refreshDownloadsPageCache(project, env.WEBSITE_CACHE);
+    try {
+      await refreshDownloadsPageCache({ projectId: project, kv: env.WEBSITE_CACHE });
+    } catch (error) {
+      console.error(`Failed to refresh downloads page cache for ${project}:`, error);
+    }
   }
 }
 
 async function updateStatsCache(env: Env) {
   const { players, error } = await fetchPaperBstatsPlayerCount();
-  if (!error) {
-    await env.WEBSITE_CACHE.put(PAPER_PLAYERCOUNT_KEY, JSON.stringify({ players }));
+  if (error) {
+    console.warn(`Not updating player count cache: ${error}`);
+    return;
   }
+
+  await env.WEBSITE_CACHE.put(PAPER_PLAYERCOUNT_KEY, JSON.stringify({ players }));
 }


### PR DESCRIPTION
- Log detailed reasons for skipped/failed webhook cache refreshes
- Skip KV writes when fetched data is unchanged and refuse to cache
  responses containing errors
- Throw descriptive errors from project descriptor/version resolution
  instead of silently returning null or continuing
- Disable fetch caching for Fill API requests and handle 204 responses
  from the latest-build endpoint
- Catch and log errors in scheduled worker handlers instead of failing
  silently

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>